### PR TITLE
Restore Altlist dependency

### DIFF
--- a/control
+++ b/control
@@ -1,12 +1,12 @@
 Package: emt.paisseon.satella
 Name: Satella
-Version: 1.6
+Version: 1.6.1
 Architecture: iphoneos-arm
 Description: Modern in-app purchase cracker
 Maintainer: Lilliana
 Author: Lilliana
 Section: Tweaks (Piracy)
-Depends: firmware (>= 12.2), ws.hbang.common (>= 1.17), preferenceloader, lilliana.jinxserver
+Depends: firmware (>= 12.2), ws.hbang.common (>= 1.17), preferenceloader, lilliana.jinxserver, com.opa334.altlist (>= 1.0.7)
 Conflicts: ai.paisseon.satella
 Icon: https://paisseon.github.io/icons/satella.png
 SileoDepiction: https://paisseon.github.io/depictions/Satella.json


### PR DESCRIPTION
Fixes an issue causing the preference bundle to fail to load on devices missing AltList.